### PR TITLE
[#52] 동시성 문제 해결

### DIFF
--- a/src/main/java/com/review/rsproject/domain/Platform.java
+++ b/src/main/java/com/review/rsproject/domain/Platform.java
@@ -66,7 +66,7 @@ public class Platform extends Auditable {
     }
 
     public Platform updateStar(Long reviewCount, Long totalStar) {
-        this.star = (byte) (totalStar / reviewCount);
+        this.star = (reviewCount == 0L) ? (byte) 0 : (byte) (totalStar / reviewCount);
         return this;
     }
 

--- a/src/main/java/com/review/rsproject/domain/Platform.java
+++ b/src/main/java/com/review/rsproject/domain/Platform.java
@@ -45,6 +45,9 @@ public class Platform extends Auditable {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "platform")
     private List<Review> reviews = new ArrayList<>();
 
+    @Version
+    private Long version;
+
 
     public Platform(String name, String url, String description, Member member) {
         this.name = name;

--- a/src/main/java/com/review/rsproject/domain/Review.java
+++ b/src/main/java/com/review/rsproject/domain/Review.java
@@ -28,6 +28,7 @@ public class Review extends Auditable {
     @JoinColumn(name = "platform_id", nullable = false)
     private Platform platform;
 
+
     public Review(Platform platform, Member member, String content, Byte star) {
         this.content = content;
         this.star = star;

--- a/src/main/java/com/review/rsproject/repository/ReviewRepository.java
+++ b/src/main/java/com/review/rsproject/repository/ReviewRepository.java
@@ -2,11 +2,13 @@ package com.review.rsproject.repository;
 
 import com.review.rsproject.domain.Review;
 import com.review.rsproject.dto.response.ReviewCountDto;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,6 +17,8 @@ import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select new com.review.rsproject.dto.response.ReviewCountDto(count(r), sum(r.star)) from Review r where r.platform.id = :platformId")
     ReviewCountDto findByStar(@Param("platformId") Long platformId);
 

--- a/src/main/java/com/review/rsproject/service/ReviewPersistenceManager.java
+++ b/src/main/java/com/review/rsproject/service/ReviewPersistenceManager.java
@@ -1,0 +1,153 @@
+package com.review.rsproject.service;
+
+import com.review.rsproject.domain.Member;
+import com.review.rsproject.domain.Platform;
+import com.review.rsproject.domain.Review;
+import com.review.rsproject.dto.request.ReviewEditDto;
+import com.review.rsproject.dto.request.ReviewWriteDto;
+import com.review.rsproject.dto.response.ReviewCountDto;
+import com.review.rsproject.exception.PlatformAccessDeniedException;
+import com.review.rsproject.exception.PlatformNotFoundException;
+import com.review.rsproject.exception.ReviewAccessDeniedException;
+import com.review.rsproject.exception.ReviewNotFoundException;
+import com.review.rsproject.repository.MemberRepository;
+import com.review.rsproject.repository.PlatformRepository;
+import com.review.rsproject.repository.ReviewRepository;
+import com.review.rsproject.type.PlatformStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewPersistenceManager {
+
+
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final PlatformRepository platformRepository;
+    private final EntityManager entityManager;
+
+    @Transactional
+    public void validateAndDeleteReview(Long id) {
+        Review review = validateReview(id);
+
+        reviewRepository.delete(review);
+
+
+        refreshPlatformStar(review.getPlatform());
+    }
+
+
+    @Transactional
+    public Review validateAndWriteReview(ReviewWriteDto reviewWriteDto) {
+        Member member = validateMember();
+        Platform platform = validatePlatform(reviewWriteDto.getId());
+
+        // 리뷰 저장
+        Review review = new Review(platform, member, reviewWriteDto.getContent(), reviewWriteDto.getStar());
+        reviewRepository.save(review);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // 플랫폼 평점 업데이트
+        refreshPlatformStar(review.getPlatform());
+
+        return review;
+    }
+
+
+    @Transactional
+    public Review validateAndUpdateReview(ReviewEditDto reviewEditDto) {
+
+        // 리뷰의 수정 요청이 올바른지 검증
+        Review review = validateReview(reviewEditDto.getId());
+        Byte oldStar = review.getStar();
+
+        // 리뷰 수정
+        review.changeInfo(reviewEditDto.getContent(), reviewEditDto.getStar());
+
+        // 리뷰에서 별점이 수정되었다면 플랫폼 평점 업데이트 진행
+        if(!oldStar.equals(review.getStar())) {
+            refreshPlatformStar(review.getPlatform());
+        }
+
+        return review;
+    }
+
+
+    private Platform refreshPlatformStar(Platform platform) {
+        ReviewCountDto result = reviewRepository.findByStar(platform.getId());
+
+        platform.updateStar(result.getReviewCount(), result.getReviewTotalStar());
+
+        return platformRepository.save(platform); // 플랫폼 평점 업데이트
+    }
+
+
+
+    /*
+     *  요청에 대한 멤버 검증 메서드
+     */
+    private Member validateMember() {
+        String memberName = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Optional<Member> member = memberRepository.findByUsername(memberName);
+
+        if (member.isEmpty()) {
+            throw new UsernameNotFoundException("요청에 해당하는 유저 정보를 찾을 수 없습니다.");
+        }
+        return member.get();
+    }
+
+
+    /*
+     *   플랫폼 검증 메서드
+     */
+    public Platform validatePlatform(Long platformId) {
+        Optional<Platform> platform = platformRepository.findById(platformId);
+
+        if (platform.isEmpty()) {
+            throw new PlatformNotFoundException();
+        }
+        if (platform.get().getStatus() != PlatformStatus.ACCEPT) {
+            throw new PlatformAccessDeniedException();
+        }
+
+
+        return platform.get();
+    }
+
+
+    /*
+     * 리뷰 검증 메서드
+     * */
+
+    private Review validateReview(Long reviewId) {
+        Optional<Review> review = reviewRepository.findByIdFetchOther(reviewId);
+
+        if (review.isEmpty()) {
+            throw  new ReviewNotFoundException();
+        }
+
+        // 리뷰를 작성한 사람과 요청하는 사람의 아이디가 다른 경우 예외 처리
+        if (!SecurityContextHolder.getContext().getAuthentication().getName()
+                .equals(review.get().getMember().getUsername())) {
+            throw new ReviewAccessDeniedException();
+        }
+
+        if (review.get().getPlatform().getStatus() != PlatformStatus.ACCEPT) {
+            throw new PlatformAccessDeniedException();
+        }
+
+        return review.get();
+    }
+}

--- a/src/main/java/com/review/rsproject/service/ReviewPersistenceManager.java
+++ b/src/main/java/com/review/rsproject/service/ReviewPersistenceManager.java
@@ -15,6 +15,7 @@ import com.review.rsproject.repository.PlatformRepository;
 import com.review.rsproject.repository.ReviewRepository;
 import com.review.rsproject.type.PlatformStatus;
 import jakarta.persistence.EntityManager;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -34,6 +35,8 @@ public class ReviewPersistenceManager {
     private final ReviewRepository reviewRepository;
     private final PlatformRepository platformRepository;
     private final EntityManager entityManager;
+
+
 
     @Transactional
     public void validateAndDeleteReview(Long id) {

--- a/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
+++ b/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
@@ -49,7 +49,6 @@ public class ReviewServiceImpl implements ReviewService {
 
 
     @Override
-    @Transactional
     public Review updateReview(ReviewEditDto reviewEditDto) {
         while (true) {
             try {

--- a/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
+++ b/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
@@ -18,6 +18,7 @@ import com.review.rsproject.repository.PlatformRepository;
 import com.review.rsproject.repository.ReviewRepository;
 import com.review.rsproject.type.PlatformStatus;
 import com.review.rsproject.type.SortType;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,6 +41,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberRepository memberRepository;
     private final PlatformRepository platformRepository;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional
@@ -82,6 +84,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public void deleteReview(Long id) {
         Review review = validateReview(id);
+
         reviewRepository.delete(review);
 
         refreshPlatformStar(review.getPlatform());

--- a/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
+++ b/src/main/java/com/review/rsproject/service/ReviewServiceImpl.java
@@ -1,100 +1,87 @@
 package com.review.rsproject.service;
 
 import com.review.rsproject.common.ConstantValues;
-import com.review.rsproject.domain.Member;
 import com.review.rsproject.domain.Platform;
 import com.review.rsproject.domain.Review;
 import com.review.rsproject.dto.request.ReviewEditDto;
 import com.review.rsproject.dto.request.ReviewListDto;
 import com.review.rsproject.dto.request.ReviewWriteDto;
-import com.review.rsproject.dto.response.ReviewCountDto;
 import com.review.rsproject.dto.response.ReviewListResultDto;
-import com.review.rsproject.exception.PlatformAccessDeniedException;
-import com.review.rsproject.exception.PlatformNotFoundException;
-import com.review.rsproject.exception.ReviewAccessDeniedException;
-import com.review.rsproject.exception.ReviewNotFoundException;
-import com.review.rsproject.repository.MemberRepository;
-import com.review.rsproject.repository.PlatformRepository;
+
 import com.review.rsproject.repository.ReviewRepository;
-import com.review.rsproject.type.PlatformStatus;
+
 import com.review.rsproject.type.SortType;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.ArrayList;
-import java.util.Optional;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewServiceImpl implements ReviewService {
 
 
+    private final ReviewPersistenceManager reviewPersistenceManager;
     private final ReviewRepository reviewRepository;
-    private final MemberRepository memberRepository;
-    private final PlatformRepository platformRepository;
-    private final EntityManager entityManager;
 
     @Override
-    @Transactional
     public Review addReview(ReviewWriteDto reviewWriteDto) {
-        Member member = validateMember();
-        Platform platform = validatePlatform(reviewWriteDto.getId());
+        while (true) {
+            try {
+                return reviewPersistenceManager.validateAndWriteReview(reviewWriteDto);
+            }
+            catch (ObjectOptimisticLockingFailureException ignored) {
 
-
-        // 리뷰 저장
-        Review review = new Review(platform, member, reviewWriteDto.getContent(), reviewWriteDto.getStar());
-        reviewRepository.save(review);
-
-        // 플랫폼 평점 업데이트
-        Platform updatedPlatform = refreshPlatformStar(platform);
-        platformRepository.save(updatedPlatform);
-
-        return review;
+            }
+        }
     }
+
+
 
     @Override
     @Transactional
     public Review updateReview(ReviewEditDto reviewEditDto) {
-
-        // 리뷰의 수정 요청이 올바른지 검증
-        Review review = validateReview(reviewEditDto.getId());
-        Byte oldStar = review.getStar();
-
-        // 리뷰 수정
-        review.changeInfo(reviewEditDto.getContent(), reviewEditDto.getStar());
-
-        // 리뷰에서 별점이 수정되었다면 플랫폼 평점 업데이트 진행
-        if(!oldStar.equals(review.getStar())) {
-            refreshPlatformStar(review.getPlatform());
+        while (true) {
+            try {
+                return reviewPersistenceManager.validateAndUpdateReview(reviewEditDto);
+            }
+            catch (ObjectOptimisticLockingFailureException ignored) {
+            }
         }
 
-        return review;
     }
 
     @Override
-    @Transactional
     public void deleteReview(Long id) {
-        Review review = validateReview(id);
 
-        reviewRepository.delete(review);
-
-        refreshPlatformStar(review.getPlatform());
+        while (true) {
+            try {
+                reviewPersistenceManager.validateAndDeleteReview(id);
+                break;
+            }
+            catch (ObjectOptimisticLockingFailureException ignored) {
+            }
+        }
 
     }
+
+
 
     @Override
     public ReviewListResultDto getReviewList(ReviewListDto reviewListDto) {
-        Platform platform = validatePlatform(reviewListDto.getId());
-        
+
+        Platform platform = reviewPersistenceManager.validatePlatform(reviewListDto.getId());
+
         Pageable pageRequest = PageRequest.of(reviewListDto.getPage(), ConstantValues.PAGE_SIZE, sortConverter(reviewListDto.getSort()));
         Page<Review> reviews = reviewRepository.findByIdFromPlatform(platform.getId(), pageRequest);
 
@@ -127,6 +114,7 @@ public class ReviewServiceImpl implements ReviewService {
         return result;
     }
 
+
     /*
     * SortType -> Sort
     * */
@@ -140,69 +128,6 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
 
-    /*
-    * 플랫폼 평점 갱신
-    * */
-    private Platform refreshPlatformStar(Platform platform) {
-        ReviewCountDto result = reviewRepository.findByStar(platform.getId());
 
-        return platform.updateStar(result.getReviewCount(), result.getReviewTotalStar()); // 플랫폼 평점 업데이트
-    }
-
-
-    /*
-     *  요청에 대한 멤버 검증 메서드
-     */
-    private Member validateMember() {
-        String memberName = SecurityContextHolder.getContext().getAuthentication().getName();
-
-        Optional<Member> member = memberRepository.findByUsername(memberName);
-
-        if (member.isEmpty()) {
-            throw new UsernameNotFoundException("요청에 해당하는 유저 정보를 찾을 수 없습니다.");
-        }
-        return member.get();
-    }
-
-    /*
-    *   플랫폼 검증 메서드
-     */
-    private Platform validatePlatform(Long platformId) {
-        Optional<Platform> platform = platformRepository.findById(platformId);
-
-        if (platform.isEmpty()) {
-            throw new PlatformNotFoundException();
-        }
-        if (platform.get().getStatus() != PlatformStatus.ACCEPT) {
-            throw new PlatformAccessDeniedException();
-        }
-
-
-        return platform.get();
-    }
-
-    /*
-    * 리뷰 검증 메서드
-    * */
-
-    private Review validateReview(Long reviewId) {
-        Optional<Review> review = reviewRepository.findByIdFetchOther(reviewId);
-
-        if (review.isEmpty()) {
-            throw  new ReviewNotFoundException();
-        }
-
-        // 리뷰를 작성한 사람과 요청하는 사람의 아이디가 다른 경우 예외 처리
-        if (!SecurityContextHolder.getContext().getAuthentication().getName()
-                .equals(review.get().getMember().getUsername())) {
-            throw new ReviewAccessDeniedException();
-        }
-
-        if (review.get().getPlatform().getStatus() != PlatformStatus.ACCEPT) {
-            throw new PlatformAccessDeniedException();
-        }
-
-        return review.get();
-    }
 
 }

--- a/src/test/java/com/review/rsproject/common/CommonUtils.java
+++ b/src/test/java/com/review/rsproject/common/CommonUtils.java
@@ -1,5 +1,9 @@
 package com.review.rsproject.common;
 
+import com.review.rsproject.domain.Member;
+import com.review.rsproject.domain.Platform;
+import com.review.rsproject.type.MemberRole;
+import com.review.rsproject.type.PlatformStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -10,10 +14,19 @@ import java.util.ArrayList;
 
 public class CommonUtils {
 
+    private static final String USERNAME = "test_user";
+
+
      public static void setContextByUsername(String username) {
         UserDetails userDetails = new User(username, "123123", new ArrayList<>());
 
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+    }
+
+    public static Platform mockBuildPlatform() {
+        Member member = new Member(USERNAME, "1111", MemberRole.ROLE_USER);
+        Platform platform =new Platform("네이버", "https://naver.com", "네이버버버버", member);
+        return platform.changeInfo(platform.getDescription(), PlatformStatus.ACCEPT);
     }
 }

--- a/src/test/java/com/review/rsproject/common/CommonUtils.java
+++ b/src/test/java/com/review/rsproject/common/CommonUtils.java
@@ -1,0 +1,19 @@
+package com.review.rsproject.common;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+
+public class CommonUtils {
+
+     public static void setContextByUsername(String username) {
+        UserDetails userDetails = new User(username, "123123", new ArrayList<>());
+
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+    }
+}

--- a/src/test/java/com/review/rsproject/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/review/rsproject/integration/ReviewIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.review.rsproject.integration;
+
+import com.review.rsproject.domain.Member;
+import com.review.rsproject.domain.Platform;
+import com.review.rsproject.domain.Review;
+import com.review.rsproject.dto.request.MemberRegisterDto;
+import com.review.rsproject.dto.request.PlatformApplyDto;
+import com.review.rsproject.dto.request.PlatformEditDto;
+import com.review.rsproject.dto.request.ReviewWriteDto;
+import com.review.rsproject.repository.PlatformRepository;
+import com.review.rsproject.service.MemberService;
+import com.review.rsproject.service.PlatformService;
+import com.review.rsproject.service.ReviewService;
+import com.review.rsproject.type.PlatformStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static com.review.rsproject.common.CommonUtils.setContextByUsername;
+
+@SpringBootTest
+public class ReviewIntegrationTest {
+
+    @Autowired
+    ReviewService reviewService;
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    PlatformService platformService;
+
+    @Autowired
+    PlatformRepository platformRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    @DisplayName("리뷰 삭제")
+    @Transactional
+    void reviewDelete() {
+        // given
+            // 회원가입
+        Member member = memberService.register(new MemberRegisterDto("test13131313", "asdfg123123"));
+        setContextByUsername(member.getUsername());
+            // 플랫폼 등록
+        Platform platform = platformService.addPlatform(new PlatformApplyDto("naver", "https://naver.com", "한국의 검색엔진 플랫폼"));
+        platformService.updatePlatform(new PlatformEditDto(platform.getId(), platform.getDescription(), PlatformStatus.ACCEPT));
+
+            // 리뷰 작성
+        Review writedReview = reviewService.addReview(new ReviewWriteDto(platform.getId(), "asdsdfafdsafsxvc", (byte) 5));
+
+        // when
+        reviewService.deleteReview(writedReview.getId());
+
+
+        // then
+        entityManager.flush();
+        entityManager.clear();
+
+        Optional<Platform> findPlatform = platformRepository.findById(writedReview.getPlatform().getId());
+        if (findPlatform.isPresent()) {
+            Assertions.assertThat(findPlatform.get().getStar()).isEqualTo((byte) 0);
+            Assertions.assertThat(findPlatform.get().getReviews().size()).isEqualTo( 0);
+        }
+
+    }
+}

--- a/src/test/java/com/review/rsproject/service/PlatformServiceTest.java
+++ b/src/test/java/com/review/rsproject/service/PlatformServiceTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.review.rsproject.common.CommonUtils.setContextByUsername;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -91,12 +92,6 @@ class PlatformServiceTest {
 
     }
 
-    private void setContextByUsername(String _username) {
-        UserDetails userDetails = new User(_username, "1111", new ArrayList<>());
-
-        SecurityContext context = SecurityContextHolder.getContext();
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
-    }
 
     @Test
     @DisplayName("플랫폼 수정")

--- a/src/test/java/com/review/rsproject/service/ReviewPersistenceManagerTest.java
+++ b/src/test/java/com/review/rsproject/service/ReviewPersistenceManagerTest.java
@@ -1,0 +1,138 @@
+package com.review.rsproject.service;
+
+import com.review.rsproject.domain.Member;
+import com.review.rsproject.domain.Platform;
+import com.review.rsproject.domain.Review;
+import com.review.rsproject.dto.request.ReviewEditDto;
+
+import com.review.rsproject.dto.request.ReviewWriteDto;
+import com.review.rsproject.dto.response.ReviewCountDto;
+
+import com.review.rsproject.exception.ReviewAccessDeniedException;
+import com.review.rsproject.repository.MemberRepository;
+import com.review.rsproject.repository.PlatformRepository;
+import com.review.rsproject.repository.ReviewRepository;
+import com.review.rsproject.type.MemberRole;
+import com.review.rsproject.type.PlatformStatus;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+
+import static com.review.rsproject.common.CommonUtils.mockBuildPlatform;
+import static com.review.rsproject.common.CommonUtils.setContextByUsername;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewPersistenceManagerTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PlatformRepository platformRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+
+    @InjectMocks
+    private ReviewPersistenceManager reviewPersistenceManager;
+
+    private static final String USERNAME = "test_user";
+
+    @Test
+    @DisplayName("리뷰 작성")
+    void reviewWrite() {
+        // given
+        setContextByUsername(USERNAME);
+
+        Platform platform = mockBuildPlatform();
+
+        // 검증 Mock
+        when(platformRepository.findById(any())).thenReturn(Optional.of(platform));
+        when(memberRepository.findByUsername(USERNAME)).thenReturn(Optional.of(platform.getMember()));
+
+        // 플랫폼 평점 업데이트 Mock
+        when(reviewRepository.findByStar(any())).thenReturn(new ReviewCountDto(1L, 5L));
+
+
+        // when
+        Review review = reviewPersistenceManager.validateAndWriteReview(new ReviewWriteDto(1L, "아아아", (byte) 5));
+
+        // then
+        Assertions.assertThat(review.getPlatform().getReviews().size()).isEqualTo(1);
+
+
+    }
+
+    @Test
+    @DisplayName("리뷰 수정")
+    void reviewEdit() {
+        // given
+        setContextByUsername(USERNAME);
+
+        Review review = mockBuildReview();
+
+
+        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
+
+        // 플랫폼 평점 업데이트 Mock, 1개의 리뷰 총점 10점
+        when(reviewRepository.findByStar(any())).thenReturn(new ReviewCountDto(1L, 10L));
+
+
+        // when
+        Review result = reviewPersistenceManager.validateAndUpdateReview(new ReviewEditDto(1L, "수정된 리뷰", (byte) 10));
+
+
+
+        // then
+        Assertions.assertThat(result.getStar()).isEqualTo((byte)10);
+        Assertions.assertThat(result.getContent()).isEqualTo("수정된 리뷰");
+    }
+
+    @Test
+    @DisplayName("리뷰 수정, 다른 사람이 수정하려 하는 경우")
+    void reviewEditOther() {
+        // given
+        setContextByUsername("bad_test_user");
+
+        Review review = mockBuildReview();
+
+        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
+
+
+        // when then
+        assertThrows(ReviewAccessDeniedException.class, () -> reviewPersistenceManager.validateAndUpdateReview(new ReviewEditDto(1L, "수정된 리뷰", (byte) 10)));
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제, 다른 사람이 삭제하려는 경우")
+    void reviewDeleteOther() {
+        // given
+        setContextByUsername("bad_test_user");
+        Review review = mockBuildReview();
+        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
+
+        // then
+        assertThrows(ReviewAccessDeniedException.class, () -> reviewPersistenceManager.validateAndDeleteReview(1L));
+
+    }
+
+
+
+
+    private Review mockBuildReview() {
+        Platform platform = mockBuildPlatform();
+        return new Review(platform, platform.getMember(), "평범한 리뷰입니다.", (byte) 5);
+    }
+}

--- a/src/test/java/com/review/rsproject/service/ReviewServiceTest.java
+++ b/src/test/java/com/review/rsproject/service/ReviewServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.review.rsproject.common.CommonUtils.mockBuildPlatform;
 import static com.review.rsproject.common.CommonUtils.setContextByUsername;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,11 +46,12 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
+
+
+
 
     @Mock
-    private PlatformRepository platformRepository;
+    private ReviewPersistenceManager reviewPersistenceManager;
 
     @Mock
     private ReviewRepository reviewRepository;
@@ -56,85 +59,7 @@ class ReviewServiceTest {
     @InjectMocks
     private ReviewServiceImpl reviewService;
 
-    private static final String USERNAME = "test_user";
 
-    @Test
-    @DisplayName("리뷰 작성")
-    void reviewWrite() {
-        // given
-        setContextByUsername(USERNAME);
-
-        Platform platform = mockBuildPlatform();
-
-        // 검증 Mock
-        when(platformRepository.findById(any())).thenReturn(Optional.of(platform));
-        when(memberRepository.findByUsername(USERNAME)).thenReturn(Optional.of(platform.getMember()));
-
-            // 플랫폼 평점 업데이트 Mock
-        when(reviewRepository.findByStar(any())).thenReturn(new ReviewCountDto(1L, 5L));
-
-
-        // when
-        Review review = reviewService.addReview(new ReviewWriteDto(1L, "아아아", (byte) 5));
-
-        // then
-        Assertions.assertThat(review.getPlatform().getReviews().size()).isEqualTo(1);
-
-
-    }
-
-    @Test
-    @DisplayName("리뷰 수정")
-    void reviewEdit() {
-        // given
-        setContextByUsername(USERNAME);
-
-        Review review = mockBuildReview();
-
-
-        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
-
-            // 플랫폼 평점 업데이트 Mock, 1개의 리뷰 총점 10점
-        when(reviewRepository.findByStar(any())).thenReturn(new ReviewCountDto(1L, 10L));
-
-
-        // when
-        Review result = reviewService.updateReview(new ReviewEditDto(1L, "수정된 리뷰", (byte) 10));
-
-
-
-        // then
-        Assertions.assertThat(result.getStar()).isEqualTo((byte)10);
-        Assertions.assertThat(result.getContent()).isEqualTo("수정된 리뷰");
-    }
-
-    @Test
-    @DisplayName("리뷰 수정, 다른 사람이 수정하려 하는 경우")
-    void reviewEditOther() {
-        // given
-        setContextByUsername("bad_test_user");
-
-        Review review = mockBuildReview();
-
-        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
-
-
-        // when then
-        assertThrows(ReviewAccessDeniedException.class, () -> reviewService.updateReview(new ReviewEditDto(1L, "수정된 리뷰", (byte) 10)));
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제, 다른 사람이 삭제하려는 경우")
-    void reviewDeleteOther() {
-        // given
-        setContextByUsername("bad_test_user");
-        Review review = mockBuildReview();
-        when(reviewRepository.findByIdFetchOther(any())).thenReturn(Optional.of(review));
-
-        // then
-        assertThrows(ReviewAccessDeniedException.class, () -> reviewService.deleteReview(1L));
-
-    }
 
     @Test
     @DisplayName("리뷰 조회")
@@ -148,9 +73,11 @@ class ReviewServiceTest {
         ReviewListDto requestDto = new ReviewListDto(1L, 0, SortType.DATE_DESC);
 
             // mock
-        when(platformRepository.findById(any())).thenReturn(Optional.of(platform));
+        when(reviewPersistenceManager.validatePlatform(any())).thenReturn(platform);
         when(reviewRepository.findByIdFromPlatform(any(), any()))
                 .thenReturn(new PageImpl<>(reviews, PageRequest.of(0, ConstantValues.PAGE_SIZE), reviewCount));
+
+
 
 
         // when
@@ -163,21 +90,8 @@ class ReviewServiceTest {
         Assertions.assertThat(result.getTotalPage()).isEqualTo(2); // 총 페이지 수 검증
 
 
-
     }
 
-
-
-    private Review mockBuildReview() {
-        Platform platform = mockBuildPlatform();
-        return new Review(platform, platform.getMember(), "평범한 리뷰입니다.", (byte) 5);
-    }
-
-    private Platform mockBuildPlatform() {
-        Member member = new Member(USERNAME, "1111", MemberRole.ROLE_USER);
-        Platform platform =new Platform("네이버", "https://naver.com", "네이버버버버", member);
-        return platform.changeInfo(platform.getDescription(), PlatformStatus.ACCEPT);
-    }
 
 
     private List<Review> mockBuildBulkReview(Platform platform, Long count) {

--- a/src/test/java/com/review/rsproject/service/ReviewServiceTest.java
+++ b/src/test/java/com/review/rsproject/service/ReviewServiceTest.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.review.rsproject.common.CommonUtils.setContextByUsername;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -124,7 +125,7 @@ class ReviewServiceTest {
 
     @Test
     @DisplayName("리뷰 삭제, 다른 사람이 삭제하려는 경우")
-    void reviewDelete() {
+    void reviewDeleteOther() {
         // given
         setContextByUsername("bad_test_user");
         Review review = mockBuildReview();
@@ -165,13 +166,6 @@ class ReviewServiceTest {
 
     }
 
-
-    private void setContextByUsername(String username) {
-        UserDetails userDetails = new User(username, "123123", new ArrayList<>());
-
-        SecurityContext context = SecurityContextHolder.getContext();
-        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
-    }
 
 
     private Review mockBuildReview() {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,10 +1,10 @@
 
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.url=jdbc:h2:tcp://localhost/~/test
 spring.datasource.username=sa
 spring.datasource.password=
 
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 
 
 spring.jpa.show-sql=true


### PR DESCRIPTION
## 최종 결과
- 낙관적 락을 사용하여 작성, 수정, 삭제 시 일어나는 동시성 문제 해결

## 변경 사항
- ``Platform.class`` : 낙관적 락 사용을 위한 필드 추가
- ``ReviewServiceImpl.class`` : 동시성 문제가 일어날 가능성이 있는 메서드의 경우 ``ReviewPersistenceManager`` 로 요청을 위임하여 처리하도록 변경
- ``ReviewPersistenceManager.class`` : ``ReviewServiceImpl`` 에서 @Transactionl 호출을 위한 별도의 클래스 생성