### PR TITLE
[#63] 플랫폼 조회 통신 처리

### DIFF
--- a/member-service/src/main/java/com/prs/ms/controller/InternalMemberController.java
+++ b/member-service/src/main/java/com/prs/ms/controller/InternalMemberController.java
@@ -27,6 +27,8 @@ public class InternalMemberController {
     }
 
 
+
+
     @GetMapping("/auth/check-admin")
     public Boolean checkAdmin() {
         return internalMemberService.checkAdmin();

--- a/member-service/src/main/java/com/prs/ms/controller/InternalMemberController.java
+++ b/member-service/src/main/java/com/prs/ms/controller/InternalMemberController.java
@@ -4,13 +4,12 @@ package com.prs.ms.controller;
 import com.prs.ms.dto.MemberResponseDto;
 import com.prs.ms.service.InternalMemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/in")
 @RequiredArgsConstructor
 @Tag(name = "회원 내부 호출 API", description = "다른 서비스 호출을 위한 API")
 public class InternalMemberController {
@@ -18,12 +17,21 @@ public class InternalMemberController {
     private final InternalMemberService internalMemberService;
 
 
+
     /*
-    * 요청하는 회원 정보를 반환
+    * 특정 멤버 정보 반환
+    * */
+    @GetMapping("/members/{memberId}")
+    public MemberResponseDto memberInfo(@PathVariable("memberId") Long memberId) {
+        return internalMemberService.findMemberInfoById(memberId);
+    }
+
+    /*
+    * 요청하고 있는 멤버의 정보 반환
     * */
     @GetMapping("/member")
-    public MemberResponseDto memberInfo() {
-        return internalMemberService.getMemberInfo();
+    public MemberResponseDto requestMemberInfo() {
+        return internalMemberService.findMemberInfo();
     }
 
 

--- a/member-service/src/main/java/com/prs/ms/exception/MemberNotFoundException.java
+++ b/member-service/src/main/java/com/prs/ms/exception/MemberNotFoundException.java
@@ -3,7 +3,7 @@ package com.prs.ms.exception;
 public class MemberNotFoundException extends RuntimeException{
 
     public MemberNotFoundException() {
-
+        super("존재하지 않는 회원에 대한 요청입니다.");
     }
 
     public MemberNotFoundException(String message) {

--- a/member-service/src/main/java/com/prs/ms/service/InternalMemberService.java
+++ b/member-service/src/main/java/com/prs/ms/service/InternalMemberService.java
@@ -4,7 +4,7 @@ import com.prs.ms.dto.MemberResponseDto;
 
 public interface InternalMemberService {
 
-    MemberResponseDto getMemberInfo();
-
+    MemberResponseDto findMemberInfo();
+    MemberResponseDto findMemberInfoById(Long memberId);
     Boolean checkAdmin();
 }

--- a/member-service/src/main/java/com/prs/ms/service/InternalMemberServiceImpl.java
+++ b/member-service/src/main/java/com/prs/ms/service/InternalMemberServiceImpl.java
@@ -23,14 +23,23 @@ public class InternalMemberServiceImpl implements InternalMemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberResponseDto getMemberInfo() {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+    public MemberResponseDto findMemberInfo() {
 
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
         Member member = validateMember(username);
+
         return new MemberResponseDto(member.getId(), member.getUsername());
 
     }
-    
+
+    @Override
+    public MemberResponseDto findMemberInfoById(Long memberId) {
+        Member member = validateMember(memberId);
+
+        return new MemberResponseDto(member.getId(), member.getUsername());
+    }
+
+
 
 
 
@@ -48,7 +57,12 @@ public class InternalMemberServiceImpl implements InternalMemberService {
 
     private Member validateMember(String username) {
         Optional<Member> member = memberRepository.findByUsername(username);
-        return member.orElseThrow(() -> new MemberNotFoundException("존재하지 않는 회원에 대한 요청입니다."));
+        return member.orElseThrow(MemberNotFoundException::new);
+    }
+
+    private Member validateMember(Long memberId) {
+        Optional<Member> member = memberRepository.findById(memberId);
+        return member.orElseThrow(MemberNotFoundException::new);
 
     }
 }

--- a/member-service/src/main/java/com/prs/ms/service/InternalMemberServiceImpl.java
+++ b/member-service/src/main/java/com/prs/ms/service/InternalMemberServiceImpl.java
@@ -7,10 +7,8 @@ import com.prs.ms.repository.MemberRepository;
 import com.prs.ms.type.MemberRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -32,6 +30,9 @@ public class InternalMemberServiceImpl implements InternalMemberService {
         return new MemberResponseDto(member.getId(), member.getUsername());
 
     }
+    
+
+
 
     @Override
     public Boolean checkAdmin() {

--- a/platform-service/src/main/java/com/prs/ps/client/MemberServiceClient.java
+++ b/platform-service/src/main/java/com/prs/ps/client/MemberServiceClient.java
@@ -4,14 +4,21 @@ import com.prs.ps.dto.response.MemberInfoDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "member-service")
 @Component
 public interface MemberServiceClient {
-    @GetMapping("/api/member")
+
+
+    @GetMapping("/api/in/member")
     MemberInfoDto getMemberInfo();
 
-    @GetMapping("/api/auth/check-admin")
+    @GetMapping("/api/in/members/{memberId}")
+    MemberInfoDto getMemberInfoById(@PathVariable("memberId") Long memberId);
+
+    @GetMapping("/api/in/auth/check-admin")
     Boolean checkAdmin();
 
 }

--- a/platform-service/src/main/java/com/prs/ps/client/MemberServiceClient.java
+++ b/platform-service/src/main/java/com/prs/ps/client/MemberServiceClient.java
@@ -5,8 +5,6 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import java.util.Optional;
-
 @FeignClient(name = "member-service")
 @Component
 public interface MemberServiceClient {

--- a/platform-service/src/main/java/com/prs/ps/dto/response/MemberInfoDto.java
+++ b/platform-service/src/main/java/com/prs/ps/dto/response/MemberInfoDto.java
@@ -7,5 +7,4 @@ import lombok.Data;
 public class MemberInfoDto {
     private Long memberId;
     private String name;
-    private Boolean admin;
 }

--- a/platform-service/src/main/java/com/prs/ps/service/PlatformServiceImpl.java
+++ b/platform-service/src/main/java/com/prs/ps/service/PlatformServiceImpl.java
@@ -11,7 +11,6 @@ import com.prs.ps.dto.response.MemberInfoDto;
 import com.prs.ps.dto.response.PlatformInfoDto;
 import com.prs.ps.dto.response.PlatformPageDto;
 import com.prs.ps.dto.response.PlatformSearchResultDto;
-import com.prs.ps.exception.PlatformAccessDeniedException;
 import com.prs.ps.exception.PlatformNotFoundException;
 import com.prs.ps.repository.PlatformRepository;
 import com.prs.ps.type.PlatformStatus;
@@ -87,13 +86,13 @@ public class PlatformServiceImpl implements PlatformService {
     public PlatformInfoDto getPlatformInfo(Long id) {
         Optional<Platform> platform = platformRepository.findById(id);
 
-        if (platform.isEmpty()) {
-            throw new PlatformNotFoundException();
-        }
 
-        MemberInfoDto memberInfo = memberServiceClient.getMemberInfo();
+        Platform result = platform.orElseThrow(PlatformNotFoundException::new);
 
-        Platform result = platform.get();
+
+        MemberInfoDto memberInfo = memberServiceClient.getMemberInfoById(result.getMemberId());
+
+
 
         return PlatformInfoDto.builder()
                 .platformName(result.getName())


### PR DESCRIPTION
## 결과
- 플랫폼 조회 시 필요한 멤버 정보를 member-service 로 부터 통신하여 가져오게 변경

## 변동 사항
> member-service
> - ``InternalMemberController.class`` : 특정 멤버 ID 에 대한 정보를 반환하는 API 정의 ``/members/{memberId}``
> - ``InternalMemberServiceImpl.class`` : 특정 멤버 ID 에 대한 정보를 반환하는 비즈니스 로직 작성 ``findMemberInfoById()``

> platform-service
> - ``MemberServiceClient.class`` : 특정 멤버 ID 에 대한 정보를 가져오는 호출 스펙 정의
> - ``PlatformServiceImpl.class`` : 위 정의된 스펙을 호출하도록 적용