### PR TITLE
[#94] 리뷰 서비스 DB 다중화 적용

### DIFF
--- a/platform-service/build.gradle
+++ b/platform-service/build.gradle
@@ -52,8 +52,8 @@ dependencies {
 
 	// Zipkin
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-	implementation 'io.opentelemetry:opentelemetry-exporter-zipkin'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'io.github.openfeign:feign-micrometer'
 
 

--- a/review-service/build.gradle
+++ b/review-service/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 
 	// Zipkin
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-	implementation 'io.opentelemetry:opentelemetry-exporter-zipkin'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'io.github.openfeign:feign-micrometer'
 
 	// Prometheus

--- a/review-service/src/main/java/com/prs/rs/common/ConstantValues.java
+++ b/review-service/src/main/java/com/prs/rs/common/ConstantValues.java
@@ -7,4 +7,10 @@ public class ConstantValues {
     public static final int PAGE_SIZE = 10;
 
     public static final String PLATFORM_REFRESH_TOPIC = "platform-refresh-topic";
+
+
+    // replication
+    public static final String READ_DB = "read";
+
+    public static final String WRITE_DB = "write";
 }

--- a/review-service/src/main/java/com/prs/rs/config/ReplicaConfig.java
+++ b/review-service/src/main/java/com/prs/rs/config/ReplicaConfig.java
@@ -1,0 +1,89 @@
+package com.prs.rs.config;
+
+
+import static com.prs.rs.common.ConstantValues.READ_DB;
+import static com.prs.rs.common.ConstantValues.WRITE_DB;
+
+import com.prs.rs.source.ReplicationRoutingDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class ReplicaConfig {
+
+    @Value("${spring.datasource.write.url}")
+    private String writeUrl;
+
+    @Value("${spring.datasource.read.url}")
+    private String readUrl;
+
+    @Value("${spring.datasource.username}")
+    private String username;
+
+    @Value("${spring.datasource.password}")
+    private String password;
+
+    @Value("${spring.datasource.driver-class-name}")
+    private String driverName;
+
+    @Bean
+    public DataSource writeDataSource() {
+        return DataSourceBuilder
+            .create()
+            .type(HikariDataSource.class)
+            .url(writeUrl)
+            .driverClassName(driverName)
+            .password(password)
+            .username(username)
+            .build();
+    }
+
+    @Bean
+    public DataSource readDataSource() {
+        return DataSourceBuilder
+            .create()
+            .type(HikariDataSource.class)
+            .url(readUrl)
+            .driverClassName(driverName)
+            .password(password)
+            .username(username)
+            .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource() {
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<Object, Object>();
+        dataSourceMap.put(WRITE_DB, writeDataSource());
+        dataSourceMap.put(READ_DB, readDataSource());
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(writeDataSource());
+
+        return routingDataSource;
+
+    }
+
+    @Bean
+    @Primary
+    public DataSource routingLazyDataSource() {
+        return new LazyConnectionDataSourceProxy(routingDataSource());
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        DataSourceTransactionManager transactionManager = new DataSourceTransactionManager();
+        transactionManager.setDataSource(routingLazyDataSource());
+        return transactionManager;
+    }
+}

--- a/review-service/src/main/java/com/prs/rs/service/ReviewServiceImpl.java
+++ b/review-service/src/main/java/com/prs/rs/service/ReviewServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -58,6 +59,7 @@ public class ReviewServiceImpl implements ReviewService {
 
 
     @Override
+    @Transactional
     public Review addReview(@ValidatePlatform Long platformId, PlatformInfoDto platformInfoDto,
         @ValidateMember MemberInfoDto memberInfoDto,
         ReviewWriteDto reviewWriteDto) {
@@ -121,6 +123,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Cacheable(value = "reviews",
         key = "#reviewListDto.platformId + '#' + #reviewListDto.page + '#' + #reviewListDto.sort",
         cacheManager = "redisCacheManager")
+    @Transactional(readOnly = true)
     public ReviewListResultDto getReviewList(ReviewListDto reviewListDto,
         @ValidatePlatform Long platformId, PlatformInfoDto platform) {
 

--- a/review-service/src/main/java/com/prs/rs/source/ReplicationRoutingDataSource.java
+++ b/review-service/src/main/java/com/prs/rs/source/ReplicationRoutingDataSource.java
@@ -1,0 +1,19 @@
+package com.prs.rs.source;
+
+import static com.prs.rs.common.ConstantValues.READ_DB;
+import static com.prs.rs.common.ConstantValues.WRITE_DB;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        log.info("current dataSourceType is ReadOnly ? : {}", isReadOnly);
+        return isReadOnly ? READ_DB : WRITE_DB;
+    }
+}


### PR DESCRIPTION
## 결과
- review-service 에 DB Replication 을 사용하여 Master-Slave 로 구성

## 변경 사항
- ``ReplicaConfig.class`` : 쓰기 전용 DB 와 읽기 전용 DB 데이터 소스 등록, 스프링 트랜잭션에서 DataSource 지연 로딩 전략을 사용하도록 변경